### PR TITLE
Disable touch screen backlight when not in use.

### DIFF
--- a/src/pc/gfx/gfx_3ds.c
+++ b/src/pc/gfx/gfx_3ds.c
@@ -97,6 +97,31 @@ static void init_top_screens()
         gGfx3DSMode = GFX_3DS_MODE_WIDE_AA_12;
 }
 
+void set_bottom_screen(bool enable)
+{
+    if (n3ds_model != 3) // old 2DS shares a single backlight across both screens
+    {
+        gspLcdInit();
+        enable ? GSPLCD_PowerOnBacklight(GSPLCD_SCREEN_BOTTOM) : GSPLCD_PowerOffBacklight(GSPLCD_SCREEN_BOTTOM);
+        gspLcdExit();
+    }
+}
+
+aptHookCookie(cookie);
+
+void checkAptHook(APT_HookType hook, void UNUSED *param) {
+    if (!menu_mode) {
+        switch(hook) {
+            case APTHOOK_ONSUSPEND : set_bottom_screen(1);
+                break;
+            case APTHOOK_ONRESTORE :
+            case APTHOOK_ONWAKEUP  : set_bottom_screen(0);
+                break;
+            default:
+                break;
+        }
+    }
+}
 
 static void gfx_3ds_init(UNUSED const char *game_name, UNUSED bool start_in_fullscreen)
 {
@@ -117,6 +142,8 @@ static void gfx_3ds_init(UNUSED const char *game_name, UNUSED bool start_in_full
     }
 
     init_top_screens();
+    set_bottom_screen(0);
+    aptHook(&cookie, checkAptHook, NULL);
 }
 
 static void gfx_set_keyboard_callbacks(UNUSED bool (*on_key_down)(int scancode), UNUSED bool (*on_key_up)(int scancode), UNUSED void (*on_all_keys_up)(void))
@@ -142,6 +169,7 @@ static void gfx_3ds_main_loop(void (*run_one_game_iter)(void))
         else
         {
             int res = display_menu(&gfx_config);
+            set_bottom_screen(1);
             if (res < 0)
                 break;
             if (res > 0)
@@ -151,6 +179,7 @@ static void gfx_3ds_main_loop(void (*run_one_game_iter)(void))
                 init_top_screens();
                 consoleClear();
                 menu_mode = false;
+                set_bottom_screen(0);
             }
         }
     }


### PR DESCRIPTION
This basically just cribs my code from OpenLara, meaning it's equally as bad as the code I wrote then. That said, it all seems to work. Feel free to reject, rework, whatever you want, I'm not attached to this.

In the process of testing this, I did a lot of sleeping/waking and suspending/restoring to confirm everything in that area worked correctly. One thing I did find that's **not** caused this PR is that suspending and restoring while the printf menu is up will cause there to be no picture once you resume game. Suspending and restoring again during gameplay resolves this, but it probably needs a proper fix.