### PR TITLE
Using C3D_Fog rather than drawing over existing tris

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A prior copy of the game is required to extract the assets.
 
  - Based off [Refresh 11](https://github.com/sm64-port/sm64-port/commit/9214dddabcce4723d9b6cda2ebccbac209f6447d)
  - Multi-threaded; audio thread runs on Core 1 on O3DS and Core 2 on N3DS; needs [Luma v10.1.1](https://github.com/LumaTeam/Luma3DS/releases) or higher
- - Naive frame-skip if frame takes longer than 33.3ms (1 / 30 FPS) to render
+ - Naïve frame-skip if frame takes longer than 33.3ms (1 / 30 FPS) to render
      - Disable by building with `DISABLE_N3DS_FRAMESKIP=1`
  - Configurable controls via `sm64config.txt`
      - Use [this](https://codepen.io/benoitcaron/full/abNZrbP) online editor from [BenoitCaron](https://github.com/BenoitCaron).
@@ -116,8 +116,6 @@ git clone https://github.com/mkst/sm64-port.git
 
 cd sm64-port
 
-git checkout 3ds-port
-
 # go and copy the baserom to c:\temp (create that directory in Windows Explorer)
 cp /mnt/c/temp/baserom.us.z64 ./
 
@@ -133,16 +131,18 @@ make -j4
 
 ### Windows (MSYS2)
 
-WSL is the preferred route, but you can also use MSYS2 to compile.
+WSL is the preferred route, but you can also use MSYS2 (MINGW64) to compile.
+
+For each instruction copy and paste the contents into the **MING64** console.
 
 **Get MSYS2:**
 
 Navigate to https://www.msys2.org/ and download the installer.
 
-**Install and Run MSYS2:**
+**Install and Run MINGW64:**
 
 ```
-Next, Next, Next, Finish (keep the box checked to run now).
+Next, Next, Next, Finish (keep the box checked to "Run MSYS 64bit now").
 ```
 
 **Add keyserver for package validation:**
@@ -175,7 +175,7 @@ EOF
 pacman -Syu --noconfirm
 ```
 
-MSYS2 may close itself when done, if it does, find `MSYS2 MinGW 64bit` in your Start Menu and open again.
+MINGW64 may close itself when done, if it does, find `MSYS2 MinGW 64bit` in your Start Menu and open again.
 
 **Install Dependencies:**
 
@@ -186,10 +186,10 @@ pacman -S 3ds-dev git make python3 mingw-w64-x86_64-gcc --noconfirm
 **Setup Environment Variables:**
 
 ```sh
-export PATH=$PATH:/opt/devkitpro/tools/bin
-export DEVKITPRO=/opt/devkitpro
-export DEVKITARM=/opt/devkitpro/devkitARM
-export DEVKITPPC=/opt/devkitpro/devkitPPC
+export PATH=$PATH:/opt/devkitpro/tools/bin && echo "OK!"
+export DEVKITPRO=/opt/devkitpro && echo "OK!"
+export DEVKITARM=/opt/devkitpro/devkitARM && echo "OK!"
+export DEVKITPPC=/opt/devkitpro/devkitPPC && echo "OK!"
 ```
 
 **Clone Repository:**
@@ -201,20 +201,14 @@ git clone https://github.com/mkst/sm64-port.git
 **Navigate into freshly checked out repo:**
 
 ```sh
-cd sm64-port
+cd sm64-port && echo "OK!"
 ```
 
 **Copy in baserom.XX.z64:**
 
-This assumes that you have create the directory `c:\temp` via Windows Explorer and copied the `baserom.XX.z64` to it.
+This assumes that you have create the directory `c:\temp` via Windows Explorer and copied the Super Mario 64 `baserom.XX.z64` to it.
 ```sh
-cp /c/temp/baserom.us.z64 ./ # change 'us' to 'eu', 'jp' or 'sh' as appropriate
-```
-
-**Checkout this branch:**
-
-```sh
-git checkout 3ds-port
+cp /c/temp/baserom.us.z64 ./ && echo "OK!" # change 'us' to 'eu', 'jp' or 'sh' as appropriate
 ```
 
 **Compile:**

--- a/enhancements/60fps.patch
+++ b/enhancements/60fps.patch
@@ -657,7 +657,7 @@ index 8d4daa5..7ce2b22 100644
      gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(mtx++),
                G_MTX_MODELVIEW | G_MTX_MUL | G_MTX_PUSH);
 diff --git a/src/game/ingame_menu.c b/src/game/ingame_menu.c
-index b9a43df..281e0f3 100644
+index 24054ff..57dce69 100644
 --- a/src/game/ingame_menu.c
 +++ b/src/game/ingame_menu.c
 @@ -111,6 +111,41 @@ u8 gMenuHoldKeyIndex = 0;
@@ -1805,7 +1805,7 @@ index 3673a1a..e65c3bd 100644
      switch (transType) {
          case WARP_TRANSITION_FADE_FROM_COLOR:
 diff --git a/src/menu/intro_geo.c b/src/menu/intro_geo.c
-index 2d49d06..31cb72f 100644
+index cf96247..d1a4d85 100644
 --- a/src/menu/intro_geo.c
 +++ b/src/menu/intro_geo.c
 @@ -1,5 +1,6 @@
@@ -1857,10 +1857,10 @@ index 2d49d06..31cb72f 100644
          gSPDisplayList(displayListIter++, &intro_seg7_dl_0700B3A0);
          gSPPopMatrix(displayListIter++, G_MTX_MODELVIEW);
 diff --git a/src/pc/gfx/gfx_citro3d.c b/src/pc/gfx/gfx_citro3d.c
-index be2c36b..7f085f6 100644
+index 39841cb..d422e29 100644
 --- a/src/pc/gfx/gfx_citro3d.c
 +++ b/src/pc/gfx/gfx_citro3d.c
-@@ -836,7 +836,7 @@ static void gfx_citro3d_init(void)
+@@ -774,7 +774,7 @@ static void gfx_citro3d_init(void)
      C3D_DepthTest(false, GPU_LEQUAL, GPU_WRITE_ALL);
      C3D_AlphaTest(true, GPU_GREATER, 0x00);
  

--- a/enhancements/puppycam.patch
+++ b/enhancements/puppycam.patch
@@ -1851,7 +1851,7 @@ index 8d4daa5..c1f2099 100644
  
          if (hudDisplayFlags & HUD_DISPLAY_FLAG_TIMER) {
 diff --git a/src/game/ingame_menu.c b/src/game/ingame_menu.c
-index b9a43df..2ef25df 100644
+index 24054ff..f942731 100644
 --- a/src/game/ingame_menu.c
 +++ b/src/game/ingame_menu.c
 @@ -22,6 +22,7 @@
@@ -1862,7 +1862,7 @@ index b9a43df..2ef25df 100644
  
  u16 gDialogColorFadeTimer;
  s8 gLastDialogLineNum;
-@@ -2603,7 +2604,10 @@ s16 render_pause_courses_and_castle(void) {
+@@ -2621,7 +2622,10 @@ s16 render_pause_courses_and_castle(void) {
  #ifdef VERSION_EU
      gInGameLanguage = eu_get_language();
  #endif
@@ -1874,7 +1874,7 @@ index b9a43df..2ef25df 100644
      switch (gDialogBoxState) {
          case DIALOG_STATE_OPENING:
              gDialogLineNum = 1;
-@@ -2679,6 +2683,16 @@ s16 render_pause_courses_and_castle(void) {
+@@ -2697,6 +2701,16 @@ s16 render_pause_courses_and_castle(void) {
      if (gDialogTextAlpha < 250) {
          gDialogTextAlpha += 25;
      }

--- a/src/pc/gfx/gfx_pc.c
+++ b/src/pc/gfx/gfx_pc.c
@@ -840,13 +840,12 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx) {
         if (z_is_from_0_to_1) {
             z = (z + w) / 2.0f;
         }
-#ifdef TARGET_N3DS
-        buf_vbo[buf_vbo_len++] = v_arr[i]->y;
-        buf_vbo[buf_vbo_len++] = -v_arr[i]->x;
-        buf_vbo[buf_vbo_len++] = -z;
-#else
+
         buf_vbo[buf_vbo_len++] = v_arr[i]->x;
         buf_vbo[buf_vbo_len++] = v_arr[i]->y;
+#ifdef TARGET_N3DS
+        buf_vbo[buf_vbo_len++] = -z;
+#else
         buf_vbo[buf_vbo_len++] = z;
 #endif
         buf_vbo[buf_vbo_len++] = w;
@@ -862,14 +861,14 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx) {
             buf_vbo[buf_vbo_len++] = u / tex_width;
             buf_vbo[buf_vbo_len++] = v / tex_height;
         }
-
+#ifndef TARGET_N3DS
         if (use_fog) {
             buf_vbo[buf_vbo_len++] = rdp.fog_color.r / 255.0f;
             buf_vbo[buf_vbo_len++] = rdp.fog_color.g / 255.0f;
             buf_vbo[buf_vbo_len++] = rdp.fog_color.b / 255.0f;
             buf_vbo[buf_vbo_len++] = v_arr[i]->color.a / 255.0f; // fog factor (not alpha)
         }
-
+#endif
         for (int j = 0; j < num_inputs; j++) {
             struct RGBA *color;
             struct RGBA tmp;
@@ -995,6 +994,9 @@ static void gfx_sp_moveword(uint8_t index, uint16_t offset, uint32_t data) {
         case G_MW_FOG:
             rsp.fog_mul = (int16_t)(data >> 16);
             rsp.fog_offset = (int16_t)data;
+#ifdef TARGET_N3DS
+            gfx_rapi->set_fog(rsp.fog_mul, rsp.fog_offset);
+#endif
             break;
     }
 }
@@ -1170,6 +1172,9 @@ static void gfx_dp_set_prim_color(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
 }
 
 static void gfx_dp_set_fog_color(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
+#ifdef TARGET_N3DS
+    gfx_rapi->set_fog_color(r, g, b, a);
+#endif
     rdp.fog_color.r = r;
     rdp.fog_color.g = g;
     rdp.fog_color.b = b;

--- a/src/pc/gfx/gfx_rendering_api.h
+++ b/src/pc/gfx/gfx_rendering_api.h
@@ -30,8 +30,12 @@ struct GfxRenderingAPI {
     void (*start_frame)(void);
     void (*end_frame)(void);
     void (*finish_render)(void);
+#ifdef TARGET_N3DS
+    void (*set_fog)(uint16_t from, uint16_t to);
+    void (*set_fog_color)(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 #ifdef ENABLE_N3DS_3D_MODE
     void (*set_is_2d)(bool is_2d);
+#endif
 #endif
 };
 


### PR DESCRIPTION
closes https://github.com/mkst/sm64-port/issues/3, should yield performance improvement in levels with fog (BOB, JRB, HMC)

**Known issues:**

 - [ ] fog broken in 3D mode; `Mtx_PerspStereoTilt` is the culprit.