### PR TITLE
Fix 3D mode skybox clipping problem

### DIFF
--- a/src/game/skybox.c
+++ b/src/game/skybox.c
@@ -14,6 +14,10 @@
 #define BETTER_SKYBOX_POSITION_PRECISION
 #endif
 
+#ifdef ENABLE_N3DS_3D_MODE
+#include "pc/gfx/gfx_3ds.h"
+bool is3D;
+#endif
 /**
  * @file skybox.c
  *
@@ -66,6 +70,12 @@ struct Skybox {
 
     /// The index of the upper-left tile in the 3x3 grid that gets drawn
     s32 upperLeftTile;
+#ifdef ENABLE_N3DS_3D_MODE
+    s32 tileCol; // col and row of upper-left tile
+    s32 tileRow;
+    s32 tileColCur; // col and row in current 5x5 grid
+    s32 tileRowCur;
+#endif
 };
 
 struct Skybox sSkyBoxInfo[2];
@@ -218,6 +228,21 @@ static int get_top_left_tile_idx(s8 player) {
     s32 tileCol = sSkyBoxInfo[player].scaledX / SKYBOX_TILE_WIDTH;
     s32 tileRow = (SKYBOX_HEIGHT - sSkyBoxInfo[player].scaledY) / SKYBOX_TILE_HEIGHT;
 
+#ifdef ENABLE_N3DS_3D_MODE
+/* As a tile is exactly half of the width and height of the screen, ordinarily 2-3 tiles would be visible in 
+ * a given dimension at any given time. Increasing the FOV in 3D mode increases this to 3-4 tiles, so a 3x3
+ * grid is not enough to see 4 tiles on screen at once. Since an extra tile is needed in all directions, the
+ * grid is being changed to 5x5 when 3D mode is enabled. This calculates the new upper left tile position.  */
+ 
+    if (is3D) {
+        if (tileCol == 8) // checks for yaw = 360.0, the game treats this as the end of the 8th column
+            sSkyBoxInfo[player].tileCol = 6; // our shift moves yaw = 360.0 to the end of the 7th column
+        else 
+            sSkyBoxInfo[player].tileCol = (tileCol - 1 < 0) ? 7 : tileCol - 1; // shifts 1 left and checks wrap around
+        sSkyBoxInfo[player].tileRow = (tileRow - 1 < 0) ? 0 : tileRow - 1; // shifts 1 up and checks for top
+    }
+#endif
+    
     return tileRow * SKYBOX_COLS + tileCol;
 }
 
@@ -228,22 +253,14 @@ static int get_top_left_tile_idx(s8 player) {
  *                  into an x and y by modulus and division by SKYBOX_COLS. x and y are then scaled by
  *                  SKYBOX_TILE_WIDTH to get a point in world space.
  */
+#ifndef ENABLE_N3DS_3D_MODE // original vertex function
 Vtx *make_skybox_rect(s32 tileIndex, s8 colorIndex) {
     Vtx *verts = alloc_display_list(4 * sizeof(*verts));
     s16 x = tileIndex % SKYBOX_COLS * SKYBOX_TILE_WIDTH;
     s16 y = SKYBOX_HEIGHT - tileIndex / SKYBOX_COLS * SKYBOX_TILE_HEIGHT;
 
     if (verts != NULL) {
-#ifdef ENABLE_N3DS_3D_MODE
-        make_vertex(verts, 0, x, y, -3, 0, 0, sSkyboxColors[colorIndex][0], sSkyboxColors[colorIndex][1],
-                    sSkyboxColors[colorIndex][2], 255);
-        make_vertex(verts, 1, x, y - SKYBOX_TILE_HEIGHT, -3, 0, 31 << 5, sSkyboxColors[colorIndex][0], sSkyboxColors[colorIndex][1],
-                    sSkyboxColors[colorIndex][2], 255);
-        make_vertex(verts, 2, x + SKYBOX_TILE_WIDTH, y - SKYBOX_TILE_HEIGHT, -3, 31 << 5, 31 << 5, sSkyboxColors[colorIndex][0],
-                    sSkyboxColors[colorIndex][1], sSkyboxColors[colorIndex][2], 255);
-        make_vertex(verts, 3, x + SKYBOX_TILE_WIDTH, y, -3, 31 << 5, 0, sSkyboxColors[colorIndex][0], sSkyboxColors[colorIndex][1],
-                    sSkyboxColors[colorIndex][2], 255);
-#else
+
         make_vertex(verts, 0, x, y, -1, 0, 0, sSkyboxColors[colorIndex][0], sSkyboxColors[colorIndex][1],
                     sSkyboxColors[colorIndex][2], 255);
         make_vertex(verts, 1, x, y - SKYBOX_TILE_HEIGHT, -1, 0, 31 << 5, sSkyboxColors[colorIndex][0], sSkyboxColors[colorIndex][1],
@@ -252,12 +269,48 @@ Vtx *make_skybox_rect(s32 tileIndex, s8 colorIndex) {
                     sSkyboxColors[colorIndex][1], sSkyboxColors[colorIndex][2], 255);
         make_vertex(verts, 3, x + SKYBOX_TILE_WIDTH, y, -1, 31 << 5, 0, sSkyboxColors[colorIndex][0], sSkyboxColors[colorIndex][1],
                     sSkyboxColors[colorIndex][2], 255);
-#endif
     } else {
     }
 	
     return verts;
 }
+#else // 3D mode vertex function
+Vtx *make_skybox_rect(s32 tileIndex, s8 colorIndex, s8 player) {
+    Vtx *verts = alloc_display_list(4 * sizeof(*verts));
+    s16 x, y, z;
+    if (is3D) {
+        s16 tileColTotal = sSkyBoxInfo[player].tileCol + sSkyBoxInfo[player].tileColCur;
+        s16 tileRowTotal = sSkyBoxInfo[player].tileRow + sSkyBoxInfo[player].tileRowCur;
+        if (sSkyBoxInfo[player].tileCol == 7 && sSkyBoxInfo[player].tileColCur == 0) // check wrap around
+            x = 0 - (SKYBOX_TILE_WIDTH); // negative value required to properly wrap
+        else if (sSkyBoxInfo[player].tileCol == 7)
+            x = SKYBOX_TILE_WIDTH * (sSkyBoxInfo[player].tileColCur - 1);
+        else
+            x = tileColTotal * SKYBOX_TILE_WIDTH;
+        y = (tileRowTotal > 7) ? SKYBOX_TILE_HEIGHT : (SKYBOX_HEIGHT - tileRowTotal * SKYBOX_TILE_HEIGHT); // check for bottom
+        z = -3; // skybox depth, disappears when less than -3
+    }
+    else {
+        x = tileIndex % SKYBOX_COLS * SKYBOX_TILE_WIDTH;
+        y = SKYBOX_HEIGHT - tileIndex / SKYBOX_COLS * SKYBOX_TILE_HEIGHT;
+        z = -1; // just in case, returning this to its original value in 2D mode
+    }
+    if (verts != NULL) {
+        make_vertex(verts, 0, x, y, z, 0, 0, sSkyboxColors[colorIndex][0], sSkyboxColors[colorIndex][1],
+                    sSkyboxColors[colorIndex][2], 255);
+        make_vertex(verts, 1, x, y - SKYBOX_TILE_HEIGHT, z, 0, 31 << 5, sSkyboxColors[colorIndex][0], sSkyboxColors[colorIndex][1],
+                    sSkyboxColors[colorIndex][2], 255);
+        make_vertex(verts, 2, x + SKYBOX_TILE_WIDTH, y - SKYBOX_TILE_HEIGHT, z, 31 << 5, 31 << 5, sSkyboxColors[colorIndex][0],
+                    sSkyboxColors[colorIndex][1], sSkyboxColors[colorIndex][2], 255);
+        make_vertex(verts, 3, x + SKYBOX_TILE_WIDTH, y, z, 31 << 5, 0, sSkyboxColors[colorIndex][0], sSkyboxColors[colorIndex][1],
+                    sSkyboxColors[colorIndex][2], 255);
+    } else {
+    }
+	
+    return verts;
+}
+#endif
+
 
 /**
  * Draws a 3x3 grid of 32x32 sections of the original skybox image.
@@ -268,6 +321,25 @@ void draw_skybox_tile_grid(Gfx **dlist, s8 background, s8 player, s8 colorIndex)
     s32 row;
     s32 col;
 
+#ifdef ENABLE_N3DS_3D_MODE
+    s16 grid = (is3D) ? 5 : 3; // 5x5 only if 3D is on
+    for (row = 0; row < grid; row++) { 
+        for (col = 0; col < grid; col++) { 
+            s32 tileIndex;
+            if (is3D) {
+                sSkyBoxInfo[player].tileColCur = col; // tracking the position in the current 5x5 grid
+                sSkyBoxInfo[player].tileRowCur = row;
+                s16 tileColTotal = sSkyBoxInfo[player].tileCol + col;
+                s16 tileRowTotal = sSkyBoxInfo[player].tileRow + row;
+                if (tileColTotal > 7) tileColTotal = tileColTotal - 8; // check wrap around 
+                if (tileRowTotal > 7) tileRowTotal = 7; // check for bottom
+                tileIndex = tileColTotal + tileRowTotal * SKYBOX_COLS; // 5x5 index value
+            }
+            else tileIndex = sSkyBoxInfo[player].upperLeftTile + row * SKYBOX_COLS + col; // original index value
+            const u8 *const texture =
+                (*(SkyboxTexture *) segmented_to_virtual(sSkyboxTextures[background]))[tileIndex];
+            Vtx *vertices = make_skybox_rect(tileIndex, colorIndex, player);
+#else
     for (row = 0; row < 3; row++) {
         for (col = 0; col < 3; col++) {
             s32 tileIndex = sSkyBoxInfo[player].upperLeftTile + row * SKYBOX_COLS + col;
@@ -275,6 +347,7 @@ void draw_skybox_tile_grid(Gfx **dlist, s8 background, s8 player, s8 colorIndex)
                 (*(SkyboxTexture *) segmented_to_virtual(sSkyboxTextures[background]))[tileIndex];
             Vtx *vertices = make_skybox_rect(tileIndex, colorIndex);
 
+#endif
             gLoadBlockTexture((*dlist)++, 32, 32, G_IM_FMT_RGBA, texture);
             gSPVertex((*dlist)++, VIRTUAL_TO_PHYSICAL(vertices), 4, 0);
             gSPDisplayList((*dlist)++, dl_draw_quad_verts_0123);
@@ -311,7 +384,11 @@ void *create_skybox_ortho_matrix(s8 player) {
  * Creates the skybox's display list, then draws the 3x3 grid of tiles.
  */
 Gfx *init_skybox_display_list(s8 player, s8 background, s8 colorIndex) {
+#ifdef ENABLE_N3DS_3D_MODE
+    s32 dlCommandCount = (is3D) ? 5 + (5 * 5) * 7 : 5 + (3 * 3) * 7; // 5x5 only if 3D is on
+#else
     s32 dlCommandCount = 5 + (3 * 3) * 7; // 5 for the start and end, plus 9 skybox tiles
+#endif
     void *skybox = alloc_display_list(dlCommandCount * sizeof(Gfx));
     Gfx *dlist = skybox;
 
@@ -351,6 +428,9 @@ Gfx *create_skybox_facing_camera(s8 player, s8 background, f32 fov,
     f32 cameraFaceY = focY - posY;
     f32 cameraFaceZ = focZ - posZ;
     s8 colorIndex = 1;
+#ifdef ENABLE_N3DS_3D_MODE
+    is3D = ((gGfx3DSMode == GFX_3DS_MODE_NORMAL || gGfx3DSMode == GFX_3DS_MODE_AA_22) && gSliderLevel > 0.0f) ? true : false;
+#endif
 
     // If the first star is collected in JRB, make the sky darker and slightly green
     if (background == 8 && !(save_file_get_star_flags(gCurrSaveFileNum - 1, COURSE_JRB - 1) & 1)) {

--- a/src/pc/gfx/gfx_pc.c
+++ b/src/pc/gfx/gfx_pc.c
@@ -656,21 +656,25 @@ static void gfx_sp_vertex(size_t n_vertices, size_t dest_index, const Vtx *verti
         // trivial clip rejection
         d->clip_rej = 0;
 #ifdef ENABLE_N3DS_3D_MODE
-    if ((gGfx3DSMode == GFX_3DS_MODE_NORMAL || gGfx3DSMode == GFX_3DS_MODE_AA_22) && gSliderLevel > 0.0f) { // change clipping when 3D is enabled
-        float wx = w * 1.2f; // expanded w-range for testing vertex's x position, value is approximate for max sliderlevel
-        if (x < -wx) d->clip_rej |= 1; // only x should be tested against the expanded range
-        if (x > wx) d->clip_rej |= 2;
+    if ((gGfx3DSMode == GFX_3DS_MODE_NORMAL || gGfx3DSMode == GFX_3DS_MODE_AA_22) && gSliderLevel > 0.0f) {
+        float wMod = w * 1.2f; // expanded w-range for testing clip rejection
+        if (x < -wMod) d->clip_rej |= 1;
+        if (x > wMod) d->clip_rej |= 2;
+        if (y < -wMod) d->clip_rej |= 4;
+        if (y > wMod) d->clip_rej |= 8;
     }
     else {
         if (x < -w) d->clip_rej |= 1;
         if (x > w) d->clip_rej |= 2;
+        if (y < -w) d->clip_rej |= 4;
+        if (y > w) d->clip_rej |= 8;
     }
 #else
         if (x < -w) d->clip_rej |= 1;
         if (x > w) d->clip_rej |= 2;
-#endif
         if (y < -w) d->clip_rej |= 4;
         if (y > w) d->clip_rej |= 8;
+#endif
         if (z < -w) d->clip_rej |= 16;
         if (z > w) d->clip_rej |= 32;
 


### PR DESCRIPTION
- Changes tile grid logic from 3x3 to 5x5 if 3D mode is enabled
- Vertex clip rejection y-axis test range also needed expanding